### PR TITLE
Update the slack url

### DIFF
--- a/edmontonpy/www/templates/base.html
+++ b/edmontonpy/www/templates/base.html
@@ -52,7 +52,7 @@
                 </a>
               </li>
               <li class="nav-item d-none d-md-inline">
-                <a class="nav-link text-white-50" href="https://join.slack.com/t/edmontonpy/shared_invite/enQtNTc2MTE3MzUwMTY2LTA1MmQxYWU2Mzg5ZDk0MTZlNzEzMTkwMTk2NDFlNDQ0MDgzZTY5MmEzMGQ3MTdhYmUyYTdjNjBiODJmMzlhMjM">
+                <a class="nav-link text-white-50" href="https://devedmonton.slack.com/">
                   <span class="fa-stack font-md">
                     <i class="fas fa-circle fa-stack-2x"></i>
                     <i class="fab fa-slack-hash fa-stack-1x text-primary"></i>
@@ -109,7 +109,7 @@
             <h5 class="text-white"><u>Resources</u></h5>
             <ul class="list-unstyled text-small">
               <li><a class="text-white" href="https://github.com/EdmontonPy/edmontonpy">GitHub</a></li>
-              <li><a class="text-white" href="https://edmontonpy.slack.com/">Slack</a></li>
+              <li><a class="text-white" href="https://devedmonton-invite.herokuapp.com/">Slack</a></li>
               <li><a class="text-white" href="https://twitter.com/edmontonpy">Twitter</a></li>
             </ul>
           </div>


### PR DESCRIPTION
Dan, I've updated the links to the new slack; however if the user is already signed up they are presented with just the sign up page and are not redirected the the slack page. It might be better to not use that Herokuapp and instead use the magic invite link. Could we speak to Dev Edmonton about this?