### PR TITLE
Show meetup time in Edmonton time zone

### DIFF
--- a/edmontonpy/core/migrations/0002_meetups_to_edmonton_time.py
+++ b/edmontonpy/core/migrations/0002_meetups_to_edmonton_time.py
@@ -1,0 +1,33 @@
+import pytz
+from django.db import migrations
+
+def fix_times(apps, schema_editor):
+    """
+    Change any meetups at 23:59 UTC in the DB to be at the correct time in
+    Edmonton time, and save back as UTC.
+    """
+    Meetup = apps.get_model("core", "Meetup")
+    America_Edmonton = pytz.timezone('America/Edmonton')
+
+    bad_dates = Meetup.objects.filter(date_time__hour=23, date_time__minute=59)
+    for meetup in bad_dates:
+        date_time = meetup.date_time
+
+        # Make unaware
+        date_time = date_time.replace(tzinfo=None)
+
+        date_time = date_time.replace(hour=18, minute=30)
+        date_time = America_Edmonton.localize(date_time)
+        meetup.date_time = date_time
+
+        meetup.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_times)
+    ]

--- a/edmontonpy/core/models/tests/test_managers.py
+++ b/edmontonpy/core/models/tests/test_managers.py
@@ -4,13 +4,15 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
+from pytz import utc
 
 from edmontonpy.core.models.managers import MeetupManager
 
 
 class TestMeetupManager(unittest.TestCase):
     def setUp(self):
-        self.date_time = datetime(2018, 12, 29, 22, 30, 15, 400000)
+        # When USE_TZ is set, timezone.now is in UTC
+        self.date_time = datetime(2018, 12, 29, 22, 30, 15, 400000, tzinfo=utc)
         self.now_func = MagicMock(spec=timezone.now)
         self.now_func.return_value = self.date_time
         self.manager = MeetupManager(

--- a/edmontonpy/www/templates/index.html
+++ b/edmontonpy/www/templates/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load tz %}
 
 {% load static %}
 
@@ -27,7 +28,7 @@
   <div class="container">
     <div class="row text-center">
       <div class="col">
-        <h1 class="text-white">Next Meetup: {% if object %}{{ object.date_time }}{% else %}To Be Announced{% endif %}</h1>
+        <h1 class="text-white">Next Meetup: {% if object %}{% timezone "America/Edmonton" %}{{ object.date_time }}{% endtimezone %}{% else %}To Be Announced{% endif %}</h1>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The web page is currently saying the meetup is at 11:59 p.m.

![Screen Shot 2019-08-12 at 4 47 57 PM](https://user-images.githubusercontent.com/178162/62905047-09109780-bd26-11e9-800a-07f5eb3519a7.png)

This patch formats UTC times in the database as Edmonton time for display, and migrates any existing times at 23:59 UTC to 6:30 p.m. Edmonton time.

The times should probably be stored in Edmonton time in the DB instead to isolate them from any future changes to Alberta DST rules, but that is a bigger patch for another day.