### PR TITLE
Fix sponsor image padding and tweak columns slightly for better stacking on mobile

### DIFF
--- a/edmontonpy/www/templates/index.html
+++ b/edmontonpy/www/templates/index.html
@@ -112,16 +112,16 @@
         <h4 class="text-muted">Sponsors</h4>
       </div>
       <div class="row d-flex justify-content-around mx-2">
-        <div class="col col-md-2 my-auto">
-          <a href="https://www.startupedmonton.com/"><img class="d-block mx-auto sponsor-logo" src="{% static 'imgs/sponsors/startup-edmonton.png' %}" alt="NAIT Logo"></a>
+          <div class="col-sm-12 col-md-4 mb-3 px-2" style="max-width: 100%">
+            <a href="https://www.startupedmonton.com/"><img class="d-block mx-auto sponsor-logo" src="{% static 'imgs/sponsors/startup-edmonton.png' %}" alt="NAIT Logo"></a>
+          </div>
+          <div class="col-sm-12 col-md-4 mb-3 px-2">
+            <a href="https://www.theorganicbox.ca/"><img class="d-block mx-auto sponsor-logo" src="{% static 'imgs/sponsors/the-organic-box.jpg' %}" alt="The Organic Box Logo"></a>
+          </div>
+          <div class="col-sm-12 col-md-4 px-2">
+            <a href="https://liftinteractive.com/"><img class="d-block mx-auto sponsor-logo" src="{% static 'imgs/sponsors/lift-interactive.png' %}" alt="Lift Interactive Logo"></a>
+          </div>
         </div>
-        <div class="col col-md-2 my-auto">
-          <a href="https://www.theorganicbox.ca/"><img class="d-block mx-auto sponsor-logo" src="{% static 'imgs/sponsors/the-organic-box.jpg' %}" alt="The Organic Box Logo"></a>
-        </div>
-        <div class="col col-md-2 my-auto">
-          <a href="https://liftinteractive.com/"><img class="d-block mx-auto sponsor-logo" src="{% static 'imgs/sponsors/lift-interactive.png' %}" alt="Lift Interactive Logo"></a>
-        </div>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
###### Note: This is my first PR for an open source project so apologies in advance if I've messed something up or haven't followed the guidelines correctly. I won't be offended at all if this PR gets rejected as I can use it as a learning experience for next time.

---

1. Spacing around images should be a bit better now on mobile

2. The sponsor images now snap to stacked grid a bit more reliably on mobile (not perfect - ipad size causes only the lift image to wrap but I couldn't figure out how to fix that, I bet I'm missing something pretty obvious)

---

## Before

###### Galaxy S5
![Images - Before - Galaxy S5](https://user-images.githubusercontent.com/14207512/65066870-7b3a5480-d942-11e9-8ccf-35736fc7025c.jpg)

###### Iphone
![Images - Before - iphone](https://user-images.githubusercontent.com/14207512/65066874-7d9cae80-d942-11e9-8854-8f5d1b385601.jpg)
###### Ipad
![Images - Before - ipad](https://user-images.githubusercontent.com/14207512/65066876-7f667200-d942-11e9-8b4c-679fd9bcebaf.jpg)

---

## After
![Images - After - Galaxy S5](https://user-images.githubusercontent.com/14207512/65066935-9c9b4080-d942-11e9-81aa-5c1c534bba0b.jpg)
![Images - After - iphone](https://user-images.githubusercontent.com/14207512/65066945-9f963100-d942-11e9-82b5-9ee23f963861.jpg)
![Images - After - ipad](https://user-images.githubusercontent.com/14207512/65066948-a1f88b00-d942-11e9-9911-d719fb953c3c.jpg)
