### PR TITLE
30 - Add YouTube Channel Link

### DIFF
--- a/edmontonpy/www/templates/base.html
+++ b/edmontonpy/www/templates/base.html
@@ -66,6 +66,13 @@
                   </span>
                 </a>
               </li>
+              <li class="nav-item d-none d-md-inline">
+                <a class="nav-link text-white-50" href="https://www.youtube.com/playlist?list=PLwNT4e8fY2ZiJj5NSKWWzveRlYO5nxtVn">
+                  <span class="fa-stack font-md">
+                    <i class="fab fa-youtube fa-stack-2x"></i>
+                  </span>
+                </a>
+              </li>
             </ul>
           </div>
         </div>

--- a/edmontonpy/www/templates/base.html
+++ b/edmontonpy/www/templates/base.html
@@ -118,6 +118,7 @@
               <li><a class="text-white" href="https://github.com/EdmontonPy/edmontonpy">GitHub</a></li>
               <li><a class="text-white" href="https://devedmonton-invite.herokuapp.com/">Slack</a></li>
               <li><a class="text-white" href="https://twitter.com/edmontonpy">Twitter</a></li>
+              <li><a class="text-white" href="https://www.youtube.com/playlist?list=PLwNT4e8fY2ZiJj5NSKWWzveRlYO5nxtVn">YouTube</a></li>
             </ul>
           </div>
           <div class="col-6 col-md">


### PR DESCRIPTION
Added the YouTube channel link to the top navbar and the footer. It links to the Edmonton Python Meetup Playlist as per the request from Slack.

---
###### Top Navbar
![YouTube Link Top Navbar](https://user-images.githubusercontent.com/14207512/65068685-4e883c00-d946-11e9-8373-429a081d3e5b.jpg)

###### Footer
![YouTube Link Footer](https://user-images.githubusercontent.com/14207512/65068696-534cf000-d946-11e9-87e0-3c4d4f32e80c.jpg)
