### PR TITLE
Some time fixes

### DIFF
--- a/edmontonpy/core/models/managers.py
+++ b/edmontonpy/core/models/managers.py
@@ -1,6 +1,11 @@
+import datetime
+
 from django.db import models
 from django.utils import timezone
 
+# Keep showing an already-started meetup as the ‘next’ meetup until this long
+# after the meetup start time.
+DEFAULT_MEETUP_DURATION = datetime.timedelta(hours=4)
 
 class MeetupManager(models.Manager):
     def __init__(self, *args, now_func=None, **kwargs):
@@ -13,8 +18,10 @@ class MeetupManager(models.Manager):
         if date_time is None:
             date_time = self.now_func()
 
+
+
         return super().get_queryset().filter(
-            date_time__gt=date_time
+            date_time__gt=date_time - DEFAULT_MEETUP_DURATION
         ).order_by(
             'date_time'
         )[0:1].get()

--- a/edmontonpy/core/models/objects.py
+++ b/edmontonpy/core/models/objects.py
@@ -1,5 +1,8 @@
+import pytz
+
 from .dals import MeetupDAL, PresentationDAL, PresenterDAL, SponsorDAL
 
+America_Edmonton = pytz.timezone('America/Edmonton')
 
 class Meetup(MeetupDAL):
     @property
@@ -7,7 +10,7 @@ class Meetup(MeetupDAL):
         return self.url != ''
 
     def __str__(self):
-        return f'{self.date_time}'
+        return f'{self.date_time.astimezone(America_Edmonton)}'
 
 
 class Presentation(PresentationDAL):

--- a/edmontonpy/core/models/tests/test_managers.py
+++ b/edmontonpy/core/models/tests/test_managers.py
@@ -6,7 +6,9 @@ from unittest.mock import MagicMock, patch
 from django.utils import timezone
 from pytz import utc
 
-from edmontonpy.core.models.managers import MeetupManager
+from edmontonpy.core.models.managers import (
+    MeetupManager, DEFAULT_MEETUP_DURATION
+)
 
 
 class TestMeetupManager(unittest.TestCase):
@@ -15,16 +17,14 @@ class TestMeetupManager(unittest.TestCase):
         self.date_time = datetime(2018, 12, 29, 22, 30, 15, 400000, tzinfo=utc)
         self.now_func = MagicMock(spec=timezone.now)
         self.now_func.return_value = self.date_time
-        self.manager = MeetupManager(
-            now_func=self.now_func
-        )
+        self.manager = MeetupManager(now_func=self.now_func)
 
     def test_init(self):
         manager = MeetupManager()
         self.assertIsInstance(manager, MeetupManager)
         self.assertEqual(manager.now_func, timezone.now)
 
-    @patch('django.db.models.Manager.get_queryset')
+    @patch("django.db.models.Manager.get_queryset")
     def _next_meetup_test(self, base_class, **kwargs):
         base_class.return_value = base_class
         base_class.filter.return_value = base_class
@@ -32,8 +32,10 @@ class TestMeetupManager(unittest.TestCase):
         base_class.__getitem__.return_value = base_class
         base_class.get.return_value = base_class
         queryset = self.manager.next_meetup(**kwargs)
-        base_class.filter.assert_called_once_with(date_time__gt=self.date_time)
-        base_class.order_by.assert_called_once_with('date_time')
+        base_class.filter.assert_called_once_with(
+            date_time__gt=self.date_time - DEFAULT_MEETUP_DURATION
+        )
+        base_class.order_by.assert_called_once_with("date_time")
         base_class.__getitem__.assert_called_once_with(slice(0, 1, None))
         self.assertEqual(queryset, base_class)
 

--- a/edmontonpy/core/models/tests/test_objects.py
+++ b/edmontonpy/core/models/tests/test_objects.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import pytz
+
 from edmontonpy.core.models.dals import (
     MeetupDAL, PresentationDAL, PresenterDAL, SponsorDAL)
 from edmontonpy.core.models.objects import (
@@ -12,7 +14,8 @@ class TestMeetup(ModelTest):
     SUB_CLASSES = (MeetupDAL, )
 
     def setUp(self):
-        self.date_time = datetime(2018, 12, 29, 22, 30, 15, 400000)
+        self.date_time = datetime(2018, 12, 29, 22, 30, 15, 400000,
+                                  tzinfo=pytz.timezone('America/Edmonton'))
         self.model = self.MODEL_CLASS(
             date_time=self.date_time,
             url='',


### PR DESCRIPTION
  - Keep showing the current meetup on the website until 4 hours after
    start time

  - Show tz offset (e.g., “2019-09-12 17:30:00-06:00”) in meetup list in
    admin

  - Interpret entered times in admin interface as Edmonton time